### PR TITLE
add version to docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "2.4"
 services:
   python:
     build:


### PR DESCRIPTION
I have an error  while `make python_docker`
![image](https://user-images.githubusercontent.com/242871/99505833-6320f380-2992-11eb-9315-4313fa1e052d.png)

seems we have to determine `docker-compose.yml` version